### PR TITLE
Add Orientation Option for PrintJob

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is currently very alpha-stage software and will be evolving quickly.  Pleas
 doc = File.read!("tps_report.pdf") 
 printer_uri = "http://localhost:631/printers/HP_Color_LaserJet"
 
-Hippy.Operation.PrintJob.new(printer_uri, doc, job_name: "TPS Report")
+Hippy.Operation.PrintJob.new(printer_uri, doc, job_name: "TPS Report", orientation: Hippy.Protocol.Orientation.portrait())
 |> Hippy.send_operation()
 
 {:ok,

--- a/lib/encoder.ex
+++ b/lib/encoder.ex
@@ -8,13 +8,19 @@ defmodule Hippy.Encoder do
 
   @doc "Encodes an IPP request into its binary form."
   def encode(%Request{} = req) do
-    bin =
+    # TODO: Deal with invalid tag error in the middle of the loop.
+    operation_attributes_bin =
       for attribute <- req.operation_attributes, into: request_header(req) do
-        # TODO: Deal with invalid tag error in the middle of loop.
         encode_attribute(attribute)
       end
 
-    <<bin::binary, DelimiterTag.end_of_attributes()::8-signed, req.data :: binary>>
+    job_attributes_bin =
+      for attribute <- req.job_attributes, into: "" do
+        encode_attribute(attribute)
+      end
+
+    <<operation_attributes_bin::binary, job_attributes_bin::binary,
+      DelimiterTag.end_of_attributes()::8-signed, req.data::binary>>
   end
 
   defp encode_attribute({tag, name, value})

--- a/lib/operation/print_job.ex
+++ b/lib/operation/print_job.ex
@@ -6,6 +6,7 @@ defmodule Hippy.Operation.PrintJob do
   @def_charset "utf-8"
   @def_lang "en"
   @def_job_name "Untitled Job"
+  @def_orientation Hippy.Protocol.Orientation.portrait()
 
   @enforce_keys [:printer_uri, :document]
 
@@ -13,7 +14,8 @@ defmodule Hippy.Operation.PrintJob do
             document: nil,
             charset: @def_charset,
             language: @def_lang,
-            job_name: @def_job_name
+            job_name: @def_job_name,
+            orientation: @def_orientation
 
   def new(printer_uri, document, opts \\ []) do
     %__MODULE__{
@@ -21,7 +23,8 @@ defmodule Hippy.Operation.PrintJob do
       document: document,
       job_name: Keyword.get(opts, :job_name, @def_job_name),
       charset: Keyword.get(opts, :charset, @def_charset),
-      language: Keyword.get(opts, :language, @def_lang)
+      language: Keyword.get(opts, :language, @def_lang),
+      orientation: Keyword.get(opts, :orientation, @def_orientation)
     }
   end
 end
@@ -39,6 +42,9 @@ defimpl Hippy.Operation, for: Hippy.Operation.PrintJob do
         {:natural_language, "attributes-natural-language", op.language},
         {:uri, "printer-uri", target},
         {:name_without_language, "job-name", op.job_name}
+      ],
+      job_attributes: [
+        {:enum, "orientation-requested", op.orientation}
       ],
       data: op.document
     }


### PR DESCRIPTION
Thank you for this library! It worked out of the box, the only thing missing was an option to define the page orientation. It is a `job_attribute` instead of an `operation_attribute` so we had to expand the `Encoder` implementation.